### PR TITLE
Update README to reflect all available estimators

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ r = densratio(x_nu, x_de, KLIEP(), optlib=OptimLib)
 The third argument of the `densratio` function is a density ratio estimator.
 Currently, this package implements the following estimators:
 
-| Estimator | Type | References |
+| Estimator | Type<sup>1</sup> | References |
 | --------- | ---- | ---------- |
 | Kernel Mean Matching | `KMM`, `uKMM` | [Huang et al. 2006](https://papers.nips.cc/paper/3075-correcting-sample-selection-bias-by-unlabeled-data.pdf) |
 | Kullback-Leibler Importance Estimation Procedure | `KLIEP` | [Sugiyama et al. 2008](https://link.springer.com/article/10.1007/s10463-008-0197-x) |
 | Least-Squares Importance Fitting | `LSIF` | [Kanamori et al. 2009](http://www.jmlr.org/papers/volume10/kanamori09a/kanamori09a.pdf) |
+[1] We use the naming convention of prefixing the type name with `u` for the unconstrained variant of the corresponding estimator.
 
 The fourth argument `optlib` specifies the optimization package used to implement
 the estimator. Some estimators are implemented with different optimization packages

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Currently, this package implements the following estimators:
 | Kernel Mean Matching | `KMM`, `uKMM` | [Huang et al. 2006](https://papers.nips.cc/paper/3075-correcting-sample-selection-bias-by-unlabeled-data.pdf) |
 | Kullback-Leibler Importance Estimation Procedure | `KLIEP` | [Sugiyama et al. 2008](https://link.springer.com/article/10.1007/s10463-008-0197-x) |
 | Least-Squares Importance Fitting | `LSIF` | [Kanamori et al. 2009](http://www.jmlr.org/papers/volume10/kanamori09a/kanamori09a.pdf) |
+
 [1] We use the naming convention of prefixing the type name with `u` for the unconstrained variant of the corresponding estimator.
 
 The fourth argument `optlib` specifies the optimization package used to implement

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ r = densratio(x_nu, x_de, KLIEP(), optlib=OptimLib)
 The third argument of the `densratio` function is a density ratio estimator.
 Currently, this package implements the following estimators:
 
-| Estimator | References |
-| --------- | ---------- |
-| KMM       | [Huang et al. 2006](https://papers.nips.cc/paper/3075-correcting-sample-selection-bias-by-unlabeled-data.pdf) |
-| KLIEP     | [Sugiyama et al. 2008](https://link.springer.com/article/10.1007/s10463-008-0197-x) |
-| LSIF      | [Kanamori et al. 2009](http://www.jmlr.org/papers/volume10/kanamori09a/kanamori09a.pdf) |
+| Estimator | Type | References |
+| --------- | ---- | ---------- |
+| Kernel Mean Matching | `KMM` (`uKMM` for the unconstrained variant) | [Huang et al. 2006](https://papers.nips.cc/paper/3075-correcting-sample-selection-bias-by-unlabeled-data.pdf) |
+| Kullback-Leibler Importance Estimation Procedure | `KLIEP` | [Sugiyama et al. 2008](https://link.springer.com/article/10.1007/s10463-008-0197-x) |
+| Least-Squares Importance Fitting | `LSIF` | [Kanamori et al. 2009](http://www.jmlr.org/papers/volume10/kanamori09a/kanamori09a.pdf) |
 
 The fourth argument `optlib` specifies the optimization package used to implement
 the estimator. Some estimators are implemented with different optimization packages

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Currently, this package implements the following estimators:
 | Kullback-Leibler Importance Estimation Procedure | `KLIEP` | [Sugiyama et al. 2008](https://link.springer.com/article/10.1007/s10463-008-0197-x) |
 | Least-Squares Importance Fitting | `LSIF` | [Kanamori et al. 2009](http://www.jmlr.org/papers/volume10/kanamori09a/kanamori09a.pdf) |
 
-[1] We use the naming convention of prefixing the type name with `u` for the unconstrained variant of the corresponding estimator.
+<sup>1</sup> We use the naming convention of prefixing the type name with `u` for the unconstrained variant of the corresponding estimator.
 
 The fourth argument `optlib` specifies the optimization package used to implement
 the estimator. Some estimators are implemented with different optimization packages

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Currently, this package implements the following estimators:
 
 | Estimator | Type | References |
 | --------- | ---- | ---------- |
-| Kernel Mean Matching | `KMM` (`uKMM` for the unconstrained variant) | [Huang et al. 2006](https://papers.nips.cc/paper/3075-correcting-sample-selection-bias-by-unlabeled-data.pdf) |
+| Kernel Mean Matching | `KMM`, `uKMM` | [Huang et al. 2006](https://papers.nips.cc/paper/3075-correcting-sample-selection-bias-by-unlabeled-data.pdf) |
 | Kullback-Leibler Importance Estimation Procedure | `KLIEP` | [Sugiyama et al. 2008](https://link.springer.com/article/10.1007/s10463-008-0197-x) |
 | Least-Squares Importance Fitting | `LSIF` | [Kanamori et al. 2009](http://www.jmlr.org/papers/volume10/kanamori09a/kanamori09a.pdf) |
 


### PR DESCRIPTION
This is my attempt to add an extra column in the summary table as to seperate estimators' name and their corresponding types in this package.