### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ r = densratiofunc(x_nu, x_de, KLIEP())
 
 ### Hyperparameter tuning
 
-Methods like `KLIEP` are equiped with tuning strategies, and its hyperparameters
+Methods like `KLIEP` are equipped with tuning strategies, and its hyperparameters
 can be found using the following line:
 
 ```julia

--- a/ext/DensityRatioEstimationGPUArraysExt.jl
+++ b/ext/DensityRatioEstimationGPUArraysExt.jl
@@ -13,7 +13,7 @@ else
 end
 using LinearAlgebra
 
-# Aviod `mat + a * I` with CUDA which involes scalar operations and is slow
+# Avoid `mat + a * I` with CUDA which involves scalar operations and is slow
 function DensityRatioEstimation.safe_diagm(mat::M, a::T) where {M<:GPUArrays.AbstractGPUArray{T,2}} where {T}
   diag = similar(mat, size(m, 1))
   fill!(diag, a)

--- a/src/kmm/jump.jl
+++ b/src/kmm/jump.jl
@@ -34,7 +34,7 @@ function DensityRatioEstimation._kmm_ratios(K, κ, dre::KMM, optlib::Type{JuMPLi
   # build the problem without constraints
   model, β = _kmm_jump_model(K, κ, dre, optlib)
 
-  # adding constriants
+  # adding constraints
   @constraint(model, 0 .≤ β)
   isinf(B) || @constraint(model, β .≤ B)
   @constraint(model, (1 - ϵ) ≤ mean(β) ≤ (1 + ϵ))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -53,7 +53,7 @@ gaussian_gramian(esq, σ::AbstractFloat) = exp.(-esq ./ 2σ^2)
     safe_diagm(mat, a)
 
 Generate a squared matrix whose diagonal is `a` that is 
-compatible to perform addition on `mat`. It hebaves 
+compatible to perform addition on `mat`. It behaves 
 differently based on `mat` is on CPU or GPU.
 
 It is compatible with

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -54,7 +54,7 @@ gaussian_gramian(esq, σ::AbstractFloat) = exp.(-esq ./ 2σ^2)
 
 Generate a squared matrix whose diagonal is `a` that is 
 compatible to perform addition on `mat`. It behaves 
-differently based on `mat` is on CPU or GPU.
+differently based on whether `mat` is on a CPU or GPU.
 
 It is compatible with
 - CuArrays.jl (see lib/cuarrays.jl)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ islinux = Sys.islinux()
 visualtests = !isCI || (isCI && islinux)
 datadir = joinpath(@__DIR__, "data")
 
-# helper funcions
+# helper functions
 include("utils.jl")
 
 # simple cases for testing


### PR DESCRIPTION
README.md
ext/DensityRatioEstimationGPUArraysExt.jl
src/kmm/jump.jl
src/utils.jl
test/runtests.jl

marking this a draft

this might be more clear - aside from fixing the typo `hebaves` - if it were as follows

It behaves differently based on whether `mat` is on a CPU or GPU.

```
$ ed -s DensityRatioEstimation.jl/src/utils.jl <<<'52,62p'
"""
    safe_diagm(mat, a)

Generate a squared matrix whose diagonal is `a` that is 
compatible to perform addition on `mat`. It hebaves 
differently based on `mat` is on CPU or GPU.

It is compatible with
- CuArrays.jl (see lib/cuarrays.jl)
- Zygote.jl (see lib/zygote.jl)
"""
$ 
```